### PR TITLE
Fix setup.py for pip10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 import re, ast, os
 from os.path import relpath, join
-from pip.req import parse_requirements
 from setuptools import setup, find_packages
 
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
 
 def get_reqs(reqs):
     return [str(ir.req) for ir in reqs]
@@ -11,7 +14,10 @@ def get_reqs(reqs):
 try:
     install_reqs = get_reqs(parse_requirements("requirements.txt"))
 except TypeError:
-    from pip.download import PipSession
+    try: #for pip >= 10
+        from pip._internal.download import PipSession
+    except ImportError: # for pip <= 9.0.3
+        from pip.download import PipSesion
     install_reqs = get_reqs(
         parse_requirements("requirements.txt", session=PipSession())
     )


### PR DESCRIPTION
With pip >= 10.0 the API points have changed, which breaks the `setup.py script.

This PR fixes now lets you install with pip >= 10