### PR TITLE
Bump to using OpenMM with Cuda 10.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,14 +1,8 @@
 {
-    "build_requirements": {
-        "gpu": 1,
-        "instance_tags": [
-            "cuda9"
-        ]
-    },
     "conda_channels": [
         "conda-forge",
+        "conda-forge/label/testing",
         "mobleylab",
-        "omnia/label/cuda90",
         "omnia",
         "OpenEye/label/Orion",
         "Solvationtools",
@@ -18,6 +12,7 @@
         "ambermini==16.16.0",
         "alchemy==1.2.3",
         "cerberus==1.1",
+        "cudatoolkit=10.1",
         "hdbscan==0.8.12",
         "gromacs_p2",
         "matplotlib==3.0.3",
@@ -26,7 +21,7 @@
         "oeommtools==0.1.10",
         "openforcefield==0.5.1",
         "openforcefields==1.0.0",
-        "openmm==7.4.0",
+        "openmm==7.4.1",
         "openmmtools==0.18.3",
         "openmoltools==0.8.1",
         "packmol==18.169",
@@ -36,15 +31,14 @@
         "pymbar==3.0.3",
         "pyyaml==3.13",
         "pyparsing==2.3.0",
-        "python==3.6.6",
         "seaborn==0.8.1",
         "smirnoff99frosst=1.0.5",
         "sstmap==1.1.2",
         "yank==0.24.1"
     ],
     "name": "OpenEye MD Floes",
-    "python_version": "3.6",
+    "python_version": "3.6.6",
     "requirements": "requirements_dev.txt",
     "uuid": "8ad7e185-9b86-4112-a2e7-a367e5123e29",
-    "version": "0.9.6"
+    "version": "0.10.0a1",
 }


### PR DESCRIPTION
These are some changes to switch to Cuda 10.1 for the Orion 2020.1.1 release where Cuda 9 has been removed from containers, instead preferring that users install cuda through conda. No longer need GPUs at build time.

The gromacs floes don't work in this, due to having been built against Cuda 9. Could switch to installing cuda 9 in conda and it should work.

Other suggested changes that were not made in this PR:

- Bump to a newer base os (amazonlinux1 or amazonlinux2)
- Bump to Python 3.7 or newer (performance improvements, staying current, etc)